### PR TITLE
feat(chromium): make the paper size unit configurable

### DIFF
--- a/src/Modules/Chromium.php
+++ b/src/Modules/Chromium.php
@@ -16,8 +16,16 @@ class Chromium
 {
     use MultipartFormDataModule;
 
+    public const SIZE_UNIT_INCHES = 1;
+    public const SIZE_UNIT_CENTIMETERS = 1/2.54;
+    public const SIZE_UNIT_MILLIMETERS = 0.1/2.54;
+
     /**
-     * Overrides the default paper size, in inches.
+     * Overrides the default paper size.
+     *
+     * By default, the values have to be set in inches.
+     * Set the `$unit` with one of the `SIZE_UNIT_*` class constants if you want to use another unit.
+     * You can also set any floating number here, which will be multiplied with `$width` and `$height` to convert to inches.
      *
      * Examples of paper size (width x height):
      *
@@ -33,10 +41,10 @@ class Chromium
      * A5 - 5.83 x 8.27
      * A6 - 4.13 x 5.83
      */
-    public function paperSize(float $width, float $height): self
+    public function paperSize(float $width, float $height, float $unitFactor = self::SIZE_UNIT_INCHES): self
     {
-        $this->formValue('paperWidth', $width);
-        $this->formValue('paperHeight', $height);
+        $this->formValue('paperWidth', $width * $unitFactor);
+        $this->formValue('paperHeight', $height * $unitFactor);
 
         return $this;
     }


### PR DESCRIPTION
On Chromium, we can currently only provide the page size in inches. I'm sure there are technical reasons behind this, but it forces users to make a conversion if they are not used to imperial units.

To make it possible to use other units, I propose to:
- add a `$unitFactor` that takes a multiplier for conversion (by default, it is 1 to keep inches)
- add three constants for the most used multipliers for paper sizes (inches, centimeters, millimeters).

This approach has the advantages to keep one method to set the page size, and to allow users to provide any other multipliers they want, so they can set a size in feet or in meters, for instance.