### PR TITLE
Ignore IDE folders and allow php://tmp to be used for file streams

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /.phpcs-cache
 /.phpunit.result.cache
 /composer.lock
+.idea/*

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -25,9 +25,9 @@ class Stream
         return new self($filename, new LazyOpenStream($path, 'r'));
     }
 
-    public static function string(string $filename, string $str): self
+    public static function string(string $filename, string $str, bool $preferTemp = false, int $maxTmpSize = 2097152): self
     {
-        $inmemory = fopen('php://memory', 'rb+');
+        $inmemory = fopen(($preferTemp ? 'php://temp/maxmemory:' . $maxTmpSize  : 'php://memory'), 'rb+');
 
         if ($inmemory === false) {
             throw NativeFunctionErroed::createFromLastPhpError();


### PR DESCRIPTION
Allows to use `php://tmp` instead of `php://memory`. This will behave like `php://memory` and try to store it in RAM if it is within the specified limit (Default per [php documentation](https://www.php.net/manual/en/wrappers.php.php) 2MB). Custom limit can be passed as a parameter.

Not sure if useful in general but useful for us, since it will try to use memory to a pre-defined limit by us, and use temp if that limit is exceeded. Helps manage memory usage a bit. Change is non-breaking since the parameters are optional with default set to `false`.