### PR TITLE
Updated compatibility with earlier versions of guzzlehttp/psr7.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "php": "^7.4|^8.0|^8.1|^8.2",
     "ext-json": "*",
     "ext-mbstring": "*",
-    "guzzlehttp/psr7": "^2.1",
+    "guzzlehttp/psr7": "^1 || ^2.1",
     "php-http/discovery": "^1.14",
     "psr/http-client": "^1.0",
     "psr/http-message": "^1.0"


### PR DESCRIPTION
Some CMSs, such as Drupal, may still be using the old version of Guzzle. This PR allows to use this package with old versions.

This has been tested in PROD and works as expected.