### PR TITLE
Add setHeader method for sending custom headers to Gotenberg

### DIFF
--- a/src/ApiModule.php
+++ b/src/ApiModule.php
@@ -30,14 +30,22 @@ trait ApiModule
     }
 
     /**
+     * Adds or updates a header to send with the request to Gotenberg.
+     */
+    public function setHeader(string $name, string $value): self
+    {
+        $this->headers[$name] = $value;
+
+        return $this;
+    }
+
+    /**
      * Overrides the default UUID trace, or request ID, that identifies a
      * request in Gotenberg's logs.
      */
     public function trace(string $trace, string $header = 'Gotenberg-Trace'): self
     {
-        $this->headers[$header] = $trace;
-
-        return $this;
+        return $this->setHeader($header, $trace);
     }
 
     protected function request(string $method, ?StreamInterface $body = null): RequestInterface

--- a/tests/ApiModuleTest.php
+++ b/tests/ApiModuleTest.php
@@ -16,3 +16,18 @@ it(
         expect($request->getHeader('Gotenberg-Trace'))->toMatchArray(['debug']);
     }
 );
+
+it(
+    'creates a valid request with a custom header',
+    function (): void {
+        $dummy   = new DummyApiModule('https://my.url/');
+        $request = $dummy
+            ->trace('custom-trace-header')
+            ->setHeader('X-Test-Header', 'foo')
+            ->build();
+
+        expect($dummy->getUrl())->toBe('https://my.url');
+        expect($request->getHeader('Gotenberg-Trace'))->toMatchArray(['custom-trace-header']);
+        expect($request->getHeader('X-Test-Header'))->toMatchArray(['foo']);
+    }
+);


### PR DESCRIPTION
If you need to set arbitrary headers when making requests to Gotenberg you can use `ApiModule::trace` with a custom header name as a workaround, but figured it'd make sense to have it as a dedicated function and update `ApiModule::trace` to use it instead.