### PR TITLE
Update version compatibility for psr/http-message

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     "guzzlehttp/psr7": "^1 || ^2.1",
     "php-http/discovery": "^1.14",
     "psr/http-client": "^1.0",
-    "psr/http-message": "^1.0"
+    "psr/http-message": "^1.0|^2.0"
   },
   "require-dev": {
     "doctrine/coding-standard": "^9.0",


### PR DESCRIPTION
The version constraint for psr/http-message dependency in composer.json has been expanded to include version 2.0. This change will ensure compatibility with projects that require this newer version.