### PR TITLE
Make form value public

### DIFF
--- a/src/MultipartFormDataModule.php
+++ b/src/MultipartFormDataModule.php
@@ -92,12 +92,14 @@ trait MultipartFormDataModule
     /**
      * @param mixed $value
      */
-    public function formValue(string $name, $value): void
+    public function formValue(string $name, $value): self
     {
         $this->multipartFormData[] = [
             'name' => $name,
             'contents' => $value,
         ];
+
+        return $this;
     }
 
     protected function formFile(string $filename, StreamInterface $stream): void

--- a/src/MultipartFormDataModule.php
+++ b/src/MultipartFormDataModule.php
@@ -92,7 +92,7 @@ trait MultipartFormDataModule
     /**
      * @param mixed $value
      */
-    protected function formValue(string $name, $value): void
+    public function formValue(string $name, $value): void
     {
         $this->multipartFormData[] = [
             'name' => $name,


### PR DESCRIPTION
Make `formValue()` public so that this library can be more flexible and responsive to changes in Gotenberg. 

Refers to: https://github.com/gotenberg/gotenberg-php/pull/33