### PR TITLE
Fix typos in exceptions

### DIFF
--- a/src/Exceptions/GotenbergApiErrored.php
+++ b/src/Exceptions/GotenbergApiErrored.php
@@ -7,7 +7,7 @@ namespace Gotenberg\Exceptions;
 use Exception;
 use Psr\Http\Message\ResponseInterface;
 
-final class GotenbergApiErroed extends Exception
+final class GotenbergApiErrored extends Exception
 {
     private ResponseInterface $response;
 

--- a/src/Exceptions/NativeFunctionErrored.php
+++ b/src/Exceptions/NativeFunctionErrored.php
@@ -8,7 +8,7 @@ use RuntimeException;
 
 use function error_get_last;
 
-final class NativeFunctionErroed extends RuntimeException
+final class NativeFunctionErrored extends RuntimeException
 {
     public static function createFromLastPhpError(): self
     {


### PR DESCRIPTION
First of all: Thanks for the PHP library! Really awesome work. I noticed some typos in the Exceptions, can you maybe fix them? I know it's nothing really important but nevertheless nice if it would be fixed.
Thanks!