### PR TITLE
fix: only serialize defined cookie parameters

### DIFF
--- a/src/Modules/ChromiumCookie.php
+++ b/src/Modules/ChromiumCookie.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Gotenberg\Modules;
 
-class ChromiumCookie
+use JsonSerializable;
+
+class ChromiumCookie implements JsonSerializable
 {
     public function __construct(
         public readonly string $name,
@@ -15,5 +17,33 @@ class ChromiumCookie
         public readonly bool|null $httpOnly = null,
         public readonly string|null $sameSite = null,
     ) {
+    }
+
+    /** @return array<string, string|bool> */
+    public function jsonSerialize(): array
+    {
+        $serialized = [
+            'name' => $this->name,
+            'value' => $this->value,
+            'domain' => $this->domain,
+        ];
+
+        if ($this->path !== null) {
+            $serialized['path'] = $this->path;
+        }
+
+        if ($this->secure !== null) {
+            $serialized['secure'] = $this->secure;
+        }
+
+        if ($this->httpOnly !== null) {
+            $serialized['httpOnly'] = $this->httpOnly;
+        }
+
+        if ($this->sameSite !== null) {
+            $serialized['sameSite'] = $this->sameSite;
+        }
+
+        return $serialized;
     }
 }


### PR DESCRIPTION
Hi, 
I was looking on the new 8.4.0 version to allow sending cookies to chromium, it works great, but I found out that, when you leave `null` the facultative parameters of `ChromiumCookie`, gotenberg returns a 400 error, because the format is invalid as `null` is not understood. Removing non-supplied values work great, though. So I made a PR to change the serialization, to only serialize in the JSON object filled properties, to avoid this kind of problem. I don't know if it's the best way to do so, however.

Thank you for all your work on this library :)