### PR TITLE
Allow any number of arguments for the merge method of pdfEngines

### DIFF
--- a/src/Modules/PdfEngines.php
+++ b/src/Modules/PdfEngines.php
@@ -74,12 +74,9 @@ class PdfEngines
      *
      * Note: the merging order is determined by the order of the arguments.
      */
-    public function merge(Stream $pdf1, Stream $pdf2, Stream ...$pdfs): RequestInterface
+    public function merge(Stream ...$pdfs): RequestInterface
     {
         $index = $this->index ?? new HrtimeIndex();
-
-        $this->formFile($index->create() . '_' . $pdf1->getFilename(), $pdf1->getStream());
-        $this->formFile($index->create() . '_' . $pdf2->getFilename(), $pdf2->getStream());
 
         foreach ($pdfs as $pdf) {
             $this->formFile($index->create() . '_' . $pdf->getFilename(), $pdf->getStream());


### PR DESCRIPTION
Based on the discussion on https://github.com/gotenberg/gotenberg-php/issues/44

Just like `\array_merge()` (https://www.php.net/array_merge) allow any number of arguments for the merge method of the PdfEngines approach of creating PDFs.

This is a safe change because the "merge" endpoint from the Go library actually allows a single file to be processed.