### PR TITLE
Add a gitattribute to reduce installation size

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+/.github/                       export-ignore
+/tests/                         export-ignore
+/.gitattributes                 export-ignore
+/.gitignore                     export-ignore
+/Makefile                       export-ignore
+/phpcs.xml.dist                 export-ignore
+/phpstan.src.neon               export-ignore
+/phpunit.xml                    export-ignore


### PR DESCRIPTION
As a suggestion to reduce the size of the installed package, adding a `.gitattributes` with export-ignore's, makes it so that the default archive installed is smaller. In projects I am working on, being able to speed up installation speeds up CI a bit and the size of the vendor folder + the indexing of most modern editors.

If people do want to install the tests as a working example, this is still possible.

(was inspired after finding this article about it when making slight improvements to my companies internal packages - https://php.watch/articles/composer-gitattributes )