### PR TITLE
fix: use explicit string value for skipNetworkIdleEvent

### DIFF
--- a/src/Modules/ChromiumMultipartFormDataModule.php
+++ b/src/Modules/ChromiumMultipartFormDataModule.php
@@ -186,7 +186,7 @@ trait ChromiumMultipartFormDataModule
      */
     public function skipNetworkIdleEvent(bool $skip = true): self
     {
-        $this->formValue('skipNetworkIdleEvent', $skip ? 'true' : 'false');
+        $this->formValue('skipNetworkIdleEvent', $skip ?: '0');
 
         return $this;
     }

--- a/src/Modules/ChromiumMultipartFormDataModule.php
+++ b/src/Modules/ChromiumMultipartFormDataModule.php
@@ -186,7 +186,7 @@ trait ChromiumMultipartFormDataModule
      */
     public function skipNetworkIdleEvent(bool $skip = true): self
     {
-        $this->formValue('skipNetworkIdleEvent', $skip);
+        $this->formValue('skipNetworkIdleEvent', $skip ? 'true' : 'false');
 
         return $this;
     }


### PR DESCRIPTION
As php casts the boolean `false` to the empty string, which is not a valid value for go's `strconv.ParseBool`, it was not possible to set `skipNetworkIdleEvent` to `false`.

This change uses the explicit strings 'true' and 'false' instead to ensure the correct value is passed on the wire.