### PR TITLE
Add support for guzzlehttp/psr7 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "php": "^8.1|^8.2|^8.3|^8.4|^8.5",
     "ext-json": "*",
     "ext-mbstring": "*",
-    "guzzlehttp/psr7": "^1 || ^2.1",
+    "guzzlehttp/psr7": "^1 || ^2.1 || ^3",
     "php-http/discovery": "^1.14",
     "psr/http-client": "^1.0",
     "psr/http-message": "^1.0|^2.0"

--- a/tests/Helpers/Constraints/FormFileConstraint.php
+++ b/tests/Helpers/Constraints/FormFileConstraint.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Gotenberg\Test\Helpers\Constraints;
 
+use GuzzleHttp\Psr7\DiagnosticValue;
 use PHPUnit\Framework\Constraint\Constraint;
 
+use function class_exists;
 use function is_string;
 use function mb_strlen;
 use function sprintf;
@@ -27,14 +29,16 @@ final class FormFileConstraint extends Constraint
             return false;
         }
 
-        $length = mb_strlen($this->content);
-
         $needle = 'Content-Disposition: form-data; name="'
             . $this->fieldName
             . '"; filename="'
             . $this->filename
-            . '" Content-Length: '
-            . $length;
+            . '"';
+
+        // guzzlehttp/psr7:^3.0 removed the non-standard Content-Length header from multipart/form-data parts
+        if (! class_exists(DiagnosticValue::class)) {
+            $needle .= ' Content-Length: ' . mb_strlen($this->content);
+        }
 
         if ($this->contentType !== null) {
             $needle .= ' Content-Type: ' . $this->contentType;

--- a/tests/Helpers/Constraints/FormValueConstraint.php
+++ b/tests/Helpers/Constraints/FormValueConstraint.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Gotenberg\Test\Helpers\Constraints;
 
+use GuzzleHttp\Psr7\DiagnosticValue;
 use PHPUnit\Framework\Constraint\Constraint;
 
+use function class_exists;
 use function is_string;
 use function mb_strlen;
 use function sprintf;
@@ -25,14 +27,14 @@ final class FormValueConstraint extends Constraint
             return false;
         }
 
-        $length = mb_strlen($this->value);
+        $needle = 'Content-Disposition: form-data; name="' . $this->name . '"';
 
-        $needle = 'Content-Disposition: form-data; name="'
-            . $this->name
-            . '" Content-Length: '
-            . $length
-            . ' '
-            . $this->value;
+        // guzzlehttp/psr7:^3.0 removed the non-standard Content-Length header from multipart/form-data parts
+        if (! class_exists(DiagnosticValue::class)) {
+              $needle .= ' Content-Length: ' . mb_strlen($this->value);
+        }
+
+        $needle .= ' ' . $this->value;
 
         return str_contains($other, $needle);
     }


### PR DESCRIPTION
The Guzzle packages got new major releases recently; this PR adds support for the PSR-7 package's 3.0 release and addresses the one B/C break the test suite ran into (see https://github.com/guzzle/psr7/blob/3.0.0/UPGRADING.md#multipart-part-headers-and-metadata for details).